### PR TITLE
Allow '.' in channel names

### DIFF
--- a/lib/Bot/Pastebot/Server/Http.pm
+++ b/lib/Bot/Pastebot/Server/Http.pm
@@ -443,7 +443,7 @@ sub httpd_session_got_query {
 
   # 2003-12-22 - RC - Added _ and - as legal characters for channel
   # names.  What else?
-  if ($url =~ m!^/([\#\-\w]+)?!) {
+  if ($url =~ m!^/([\#\-\w\.]+)?!) {
 
     # set default channel from request URL, if possible
     my $prefchan = $1;


### PR DESCRIPTION
Hi,

 I noticed http://paste.scsys.co.uk/london.pm didn't pre-select the channel, here's a fix.
