### PR TITLE
pastebot web page should return status 200 (instead of 500) on success

### DIFF
--- a/lib/Bot/Pastebot/WebUtil.pm
+++ b/lib/Bot/Pastebot/WebUtil.pm
@@ -133,7 +133,7 @@ sub parse_cookie {
 sub _render_template {
   my ($template, $filename, $record) = @_;
 
-  my ($content, $error);
+  my ($content, $error) = ('', 0);
   if (open(my $template_fh, "<", $filename)) {
 
     $content = eval { $template->process($template_fh, $record) };
@@ -156,7 +156,7 @@ sub _render_template {
 
   return +{
     content => $content,
-    error => 1,
+    error => $error,
   };
 }
 


### PR DESCRIPTION
Even when there was no problem with the web page pastebot would return a status 500 code. A visitor to the page may not be aware of this problem but our monitoring would always report an 500 internal server error.

This patch replaces the constant 1 with the actual $error code that was evaluated in _render_template.
