### PR TITLE
Fix bug that caused existing pastes to be overwritten after restart

### DIFF
--- a/lib/Bot/Pastebot/Data.pm
+++ b/lib/Bot/Pastebot/Data.pm
@@ -291,7 +291,7 @@ sub initialize {
 
   if (-e "$dir/Index") {
     %paste_cache = %{retrieve "$dir/Index"};
-    $id_sequence = (sort keys %paste_cache)[-1];
+    $id_sequence = (sort { $a <=> $b } keys %paste_cache)[-1];
   }
   if (-e "ignorelist") {
     %ignores = %{retrieve 'ignorelist'};


### PR DESCRIPTION
The existing paste IDs were being sorted as strings, not numbers,
so the "highest" one was often not really the highest one, and the
when the next assigned ID already existed, that paste was silently
overwritten.
